### PR TITLE
Release 0.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='nameko-sentry',
-    version='0.0.3',
+    version='0.0.4',
     description='Nameko extension sends entrypoint exceptions to sentry',
     author='Matt Bennett',
     author_email='matt@bennett.name',


### PR DESCRIPTION
* Makes use of Raven's contexts when reporting to sentry. Now populates:
  - HTTP context with the request details, if using the @http entrypoint 
  - User context if any keys in nameko's `context_data` seem to identify a user
  - Tags context for call IDs, service and method names
  - Extra context for everything else in nameko's `context_data`
* Degrades nicely when the config file doesn't contain a `SENTRY` section at all